### PR TITLE
Fix report duplicates

### DIFF
--- a/utb/models.py
+++ b/utb/models.py
@@ -81,3 +81,6 @@ class Report(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE)
     article = models.ForeignKey(Article, on_delete=models.CASCADE)
     value = models.CharField(max_length=1, choices=VALUES)
+
+    class Meta:
+        unique_together = (("user", "article"),)

--- a/utb/views/submit_report.py
+++ b/utb/views/submit_report.py
@@ -42,9 +42,14 @@ def handler(request):
 
     previous_status = article.get_status()
 
-    report = Report(user=user,
-                    article=article,
-                    value=report_value.name)
+    qs = Report.objects.filter(user=user, article=article)
+    if len(qs) == 0:
+        report = Report(user=user,
+                        article=article,
+                        value=report_value.name)
+    else:
+        report = qs[0]
+        report.value = report_value.name
     report.save()
 
     user.n_reports += 1


### PR DESCRIPTION
This fixes a bug where it was impossible to edit a report. Now, if a user changes its report, the report will be correctly updated